### PR TITLE
fix: Correct line break replacement in Create Changelog step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           log=$(git log $(git describe --tags --abbrev=0)..HEAD --pretty=format:'* %s (%h)')
           log="${log//'%'/'%25'}"
-          log="${log//$'\n'/'%0A'}"
+          log="${log//$'\n'/"%0A"}"
           log="${log//$'\r'/'%0D'}"
           echo "log=$log" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
The line break replacement in the Create Changelog step of the GitHub Actions workflow was not functioning correctly due to the usage of single quotes.